### PR TITLE
RDM-7772 Add SI units note to English faq page (French pending)

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -215,6 +215,8 @@ Once your dataset is published, it is part of the scholarly record, and our cura
 </summary>
 
 You will have access to 1 TB of curated storage by default. If you think you will need additional storage, please contact [support@frdr-dfdr.ca](mailto:support@frdr-dfdr.ca).
+
+_NOTE: file sizes are calculated using SI units, i.e. 1000 B = 1 KB, 1000 KB = 1 MB, etc._
 </details>
 
 <details markdown="block">


### PR DESCRIPTION
closes https://computecanada.atlassian.net/browse/RDM-7772

The way bytes are presented has been standardized in `frdr_publish`, and calculations are now based on SI units (a conversion factor of 1000, rather than 1024)

FAQ > User Quotas has been updated with a note clarifying this.